### PR TITLE
Two city scheduling solution

### DIFF
--- a/20200603/TwoCityScheduling.cpp
+++ b/20200603/TwoCityScheduling.cpp
@@ -1,0 +1,16 @@
+class Solution {
+public:
+    int twoCitySchedCost(vector<vector<int>>& costs) {
+        auto cmp = [](const vector<int>& left, const vector<int>& right) {
+            return left[0] - left[1] < right[0] - right[1];
+        };
+        sort(costs.begin(), costs.end(), cmp);
+        int sum{0};
+        for (int i = 0; i < costs.size() / 2; ++i) {
+            sum += costs[i][0];
+            sum += costs[i + costs.size()/2][1];
+        }
+
+        return sum;
+    }
+};


### PR DESCRIPTION
For a person with less expense going to city A than going to city B, we want to put him to city A to save some money. This is when `person[0] < person[1]`.
For two people with both city A as preferred city, we want to put the person with more saving into city A slots first. This is when `person0[0] - person0[1] < person1[0] - person1[1]`.