### PR TITLE
Queue Reconstruction by Height 406

### DIFF
--- a/20200606/QueueReconstructionbyHeight.cpp
+++ b/20200606/QueueReconstructionbyHeight.cpp
@@ -1,0 +1,31 @@
+class Solution {
+public:
+    vector<vector<int>> reconstructQueue(vector<vector<int>>& people) {
+        auto cmp = [](const vector<int>& left, const vector<int>& right) {
+            return left[0] != right[0] ? (left[0] < right[0]) : (left[1] < right[1]);
+        };
+        sort(begin(people), end(people), cmp);
+        
+        vector<int> remPos;
+        for (int i{0}; i < people.size(); ++i) {
+            remPos.push_back(i);
+        }
+        vector<vector<int>> result(people.size(), vector<int>());
+        int sameHeight = 0;
+        int prevH = -1;
+        for (auto p: people) {
+            if (prevH == p[0]) {
+                sameHeight++;
+            }
+            else {
+                sameHeight = 0;
+            }
+            int relInd = p[1] - sameHeight;
+            int pos = remPos[relInd];
+            remPos.erase(begin(remPos) + relInd);
+            result[pos] = p;
+            prevH = p[0];
+        }
+        return result;
+    }
+};


### PR DESCRIPTION
The unprocessed shortest person `[h, k]` must stand in the remaining position `k` (0-based). And we need to mark the position `k` as occupied.
First, we sort the people first with their height `h` in ascending order, if two people have the same height, then we sort with their index `k` in ascending order.
Second, we walk through the sorted people `p` list from the shortest person. And we put him or her $ in the remaining position `p[1]`. We want to keep track of how many same height persons we have encountered using `sameHeight`. To mark the position occupied, we remove the position from the remaining position list. Then, we put the second person `p` in the sorted list to the `p[1]` position in the remaining positions. We need to adjust the relative position by `sameHeight` if the previous person is of same height.

$: him = him or her from now on.