### PR TITLE
Avoid using complex types as key for std::unordered_map

### DIFF
--- a/20200607/implicitlyDeletedDefaultCtor.cpp
+++ b/20200607/implicitlyDeletedDefaultCtor.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <unordered_map>
+#include <utility>
+
+struct mySol {
+    std::unordered_map<int, int> myWay;
+    int run() {
+        return 0;
+    };
+};
+
+int main() {
+    int i = mySol().run();
+    return 0;
+}

--- a/20200607/implicitlyDeletedDefaultCtor.cpp
+++ b/20200607/implicitlyDeletedDefaultCtor.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 struct mySol {
-    std::unordered_map<int, int> myWay;
+    std::unordered_map<std::pair<int, int>, int> myWay;
     int run() {
         return 0;
     };
@@ -11,5 +11,5 @@ struct mySol {
 
 int main() {
     int i = mySol().run();
-    return 0;
+    return i;
 }

--- a/CoinChange2.cpp
+++ b/CoinChange2.cpp
@@ -1,0 +1,30 @@
+class Solution {
+public:
+    int change(int amount, vector<int>& coins) {
+        // Sort the coins in ascending order
+        sort(begin(coins), end(coins), greater());
+        return nValidChange(amount, coins, 0, coins.size() - 1);
+    }
+    
+    int nValidChange(int rest, vector<int>& coins, size_t coinType, size_t lastCoinType) {
+        if (coinType > lastCoinType || coins.empty()) {
+            // Out of coin type
+            return rest == 0 ? 1 : 0;
+        }
+        else if (coinType == lastCoinType) {
+            // Last (smallest coin type)
+            return rest % coins[coinType] == 0 ? 1 : 0;
+        }
+        
+        int nWay = 0;
+        int maxCoinType = rest / coins[coinType];
+        
+        for (int i = maxCoinType; i >= 0; --i) {
+            nWay = nWay += nValidChange(rest - i * coins[coinType],
+                                        coins,
+                                        coinType + 1,
+                                        lastCoinType);
+        }
+        return nWay;
+    }
+};


### PR DESCRIPTION
One needs to provide a custom hash function for `std::unordered_map<std::pair<int, int>, int>`. A casual hash function may result in lots of collisions, and the collisions will hurt performance badly in real world.
See [Why can't I compile an unordered_map with a pair as key?](https://stackoverflow.com/questions/32685540/why-cant-i-compile-an-unordered-map-with-a-pair-as-key)