### PR TITLE
Power of Two

### DIFF
--- a/20200608/PowerOfTwo.cpp
+++ b/20200608/PowerOfTwo.cpp
@@ -5,15 +5,8 @@ public:
         if (n <= 0) {
             return false;
         }
-        
-        // The number should has exactly one bit as one, 
-        // and the other bits should be zero.
-        size_t nOne{0};
-        for (size_t i{0}; static_cast<unsigned int>(1<<i) <= static_cast<unsigned int>(n); ++i) {
-            if ( (static_cast<unsigned int>(n) & static_cast<unsigned int>(1 << i) )
-                == static_cast<unsigned int>(1 << i) ) ++nOne;
-            if (nOne > 1) break;
-        }
-        return nOne == 1;
+        // The number should only have one 1-bit
+        // Preserve only rightmost 1-bit
+        return n == ( n & (-n) );
     }
 };

--- a/20200608/PowerOfTwo.cpp
+++ b/20200608/PowerOfTwo.cpp
@@ -1,0 +1,7 @@
+class Solution
+{
+public:
+    bool isPowerOfTwo(int n)
+    {
+    }
+};

--- a/20200608/PowerOfTwo.cpp
+++ b/20200608/PowerOfTwo.cpp
@@ -1,7 +1,19 @@
-class Solution
-{
+class Solution {
 public:
-    bool isPowerOfTwo(int n)
-    {
+    bool isPowerOfTwo(int n) {
+        // The number should be positive
+        if (n <= 0) {
+            return false;
+        }
+        
+        // The number should has exactly one bit as one, 
+        // and the other bits should be zero.
+        size_t nOne{0};
+        for (size_t i{0}; static_cast<unsigned int>(1<<i) <= static_cast<unsigned int>(n); ++i) {
+            if ( (static_cast<unsigned int>(n) & static_cast<unsigned int>(1 << i) )
+                == static_cast<unsigned int>(1 << i) ) ++nOne;
+            if (nOne > 1) break;
+        }
+        return nOne == 1;
     }
 };


### PR DESCRIPTION
Takeaway for bit manipulation tricks:
1. Leave only the rightmost one-valued bit in a signed integer number:
`x & (-x)`.
This works because signed integers use two's complement, where `-x = ~x + 1`.
I suspect this should work regardless of the sign bit.
2. Set the rightmost one-valued bit in an integer number using:
`x & (x - 1)`.
This works for positive and negative signed integers. This also works for unsigned integers.