### PR TITLE
Implement Bellman Ford elegant solution

### DIFF
--- a/20200614/CheapestFlightsWithinKStopsBellmanFord.cpp
+++ b/20200614/CheapestFlightsWithinKStopsBellmanFord.cpp
@@ -1,0 +1,33 @@
+class Solution {
+public:
+    int findCheapestPrice(int n, vector<vector<int>>& flights, int src, int dst, int K) {
+        // K stops means K+1 Bellman Ford iterations over the edge list
+        // Bellman Ford should use V - 1 iterations, 
+        // After V - 1, it gives incorrect shortest distances when negative cycles exist.
+        // Here V = n. K <= n - 1. So K+1 <= n, so K+1 <= V, the last iteration is valid
+        // since the problem guarantees no self cycles.
+        
+        // Note vector<int> (N_SIZE, INIT_VAL)
+        vector<int> dist(n, numeric_limits<int>::max());
+        dist[src] = 0;
+        
+        for (size_t i{0}; i < K + 1; ++i)
+        {
+            vector<int> tmp = dist;
+            for (auto& edge: flights)
+            {
+                int u = edge[0], v = edge[1], uv = edge[2];
+                // Note: query the old incoming node info from dist,
+                // query and update the new temp copy for the current dst node.
+                if (dist[u] != numeric_limits<int>::max() && dist[u] + uv < tmp[v])
+                {
+                    tmp[v] = dist[u] + uv;
+                }
+            }
+            dist = tmp;
+        }
+        
+        return dist[dst] == numeric_limits<int>::max() ? -1 : dist[dst];
+    }
+};
+


### PR DESCRIPTION
In #28, I used the slow BFS approach for [787. Cheapest Flights Within K Stops](https://leetcode.com/articles/cheapest-flights-within-k-stops/). This pull request implements the much faster `O(E * K)` time and `O(V)` space solution.